### PR TITLE
feat: update rust edition to 2024 and change `asm!` to `naked_asm!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
 ﻿[workspace]
+resolver = "3"
 members = ["xtask", "fast-trap", "test-app"]
 default-members = ["xtask"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 resolver = "3"
 members = ["xtask", "fast-trap", "test-app"]
 default-members = ["xtask"]
+
+[workspace.package]
+edition = "2024"

--- a/fast-trap/Cargo.toml
+++ b/fast-trap/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fast-trap"
 description = "Provide a framework for bare-metal trap handling, aiming at ensuring performance while reusing code."
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 authors = ["YdrMaster <ydrml@hotmail.com>"]
 repository = "https://github.com/YdrMaster/fast-trap.git"
 documentation = "https://docs.rs/fast-trap"

--- a/fast-trap/Cargo.toml
+++ b/fast-trap/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fast-trap"
 description = "Provide a framework for bare-metal trap handling, aiming at ensuring performance while reusing code."
 version = "0.0.1"
-edition = "2024"
+edition.workspace = true
 authors = ["YdrMaster <ydrml@hotmail.com>"]
 repository = "https://github.com/YdrMaster/fast-trap.git"
 documentation = "https://docs.rs/fast-trap"

--- a/fast-trap/src/entire.rs
+++ b/fast-trap/src/entire.rs
@@ -1,7 +1,7 @@
-﻿use crate::{FlowContext, TrapHandler};
+use crate::{FlowContext, TrapHandler};
 use core::{
     marker::PhantomData,
-    mem::{forget, MaybeUninit},
+    mem::{MaybeUninit, forget},
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };

--- a/fast-trap/src/hal/riscv/mod.rs
+++ b/fast-trap/src/hal/riscv/mod.rs
@@ -111,14 +111,13 @@ impl FlowContext {
 #[naked]
 pub unsafe extern "C" fn reuse_stack_for_trap() {
     const LAYOUT: Layout = Layout::new::<TrapHandler>();
-    core::arch::asm!(
+    core::arch::naked_asm!(
         "   addi sp, sp, {size}
             andi sp, sp, {mask}
             ret
         ",
         size = const -(LAYOUT.size() as isize),
         mask = const !(LAYOUT.align() as isize - 1) ,
-        options(noreturn)
     )
 }
 
@@ -127,7 +126,7 @@ pub unsafe extern "C" fn reuse_stack_for_trap() {
 /// See [proto](crate::hal::doc::trap_entry).
 #[naked]
 pub unsafe extern "C" fn trap_entry() {
-    core::arch::asm!(
+    core::arch::naked_asm!(
         ".align 2",
         // 换栈
         exchange!(),
@@ -242,6 +241,5 @@ pub unsafe extern "C" fn trap_entry() {
         load!(a1[ 9] => a1),
         exchange!(),
         r#return!(),
-        options(noreturn),
     )
 }

--- a/fast-trap/src/hal/riscv/mod.rs
+++ b/fast-trap/src/hal/riscv/mod.rs
@@ -111,14 +111,16 @@ impl FlowContext {
 #[naked]
 pub unsafe extern "C" fn reuse_stack_for_trap() {
     const LAYOUT: Layout = Layout::new::<TrapHandler>();
-    core::arch::naked_asm!(
-        "   addi sp, sp, {size}
+    unsafe {
+        core::arch::naked_asm!(
+            "   addi sp, sp, {size}
             andi sp, sp, {mask}
             ret
         ",
-        size = const -(LAYOUT.size() as isize),
-        mask = const !(LAYOUT.align() as isize - 1) ,
-    )
+            size = const -(LAYOUT.size() as isize),
+            mask = const !(LAYOUT.align() as isize - 1) ,
+        )
+    }
 }
 
 /// # Safety
@@ -126,120 +128,122 @@ pub unsafe extern "C" fn reuse_stack_for_trap() {
 /// See [proto](crate::hal::doc::trap_entry).
 #[naked]
 pub unsafe extern "C" fn trap_entry() {
-    core::arch::naked_asm!(
-        ".align 2",
-        // 换栈
-        exchange!(),
-        // 加载上下文指针
-        save!(a0 => sp[2]),
-        load!(sp[0] => a0),
-        // 保存尽量少的寄存器
-        save!(ra => a0[0]),
-        save!(t0 => a0[1]),
-        save!(t1 => a0[2]),
-        save!(t2 => a0[3]),
-        save!(t3 => a0[4]),
-        save!(t4 => a0[5]),
-        save!(t5 => a0[6]),
-        save!(t6 => a0[7]),
-        // 调用快速路径函数
-        //
-        // | reg    | position
-        // | ------ | -
-        // | ra     | `TrapHandler.context`
-        // | t0-t6  | `TrapHandler.context`
-        // | a0     | `TrapHandler.scratch`
-        // | a1-a7  | 参数寄存器
-        // | sp     | sscratch
-        // | gp, tp | gp, tp
-        // | s0-s11 | 不支持
-        //
-        // > 若要保留陷入上下文，
-        // > 必须在快速路径保存 a0-a7 到 `TrapHandler.context`，
-        // > 并进入完整路径执行后续操作。
-        // >
-        // > 若要切换上下文，在快速路径设置 gp/tp/sscratch/sepc 和 sstatus。
-        "mv   a0, sp",
-        load!(sp[1] => ra),
-        "jalr ra",
-        "0:", // 加载上下文指针
-        load!(sp[0] => a1),
-        // 0：设置少量参数寄存器
-        "   beqz  a0, 0f",
-        // 1：设置所有参数寄存器
-        "   addi  a0, a0, -1
+    unsafe {
+        core::arch::naked_asm!(
+            ".align 2",
+            // 换栈
+            exchange!(),
+            // 加载上下文指针
+            save!(a0 => sp[2]),
+            load!(sp[0] => a0),
+            // 保存尽量少的寄存器
+            save!(ra => a0[0]),
+            save!(t0 => a0[1]),
+            save!(t1 => a0[2]),
+            save!(t2 => a0[3]),
+            save!(t3 => a0[4]),
+            save!(t4 => a0[5]),
+            save!(t5 => a0[6]),
+            save!(t6 => a0[7]),
+            // 调用快速路径函数
+            //
+            // | reg    | position
+            // | ------ | -
+            // | ra     | `TrapHandler.context`
+            // | t0-t6  | `TrapHandler.context`
+            // | a0     | `TrapHandler.scratch`
+            // | a1-a7  | 参数寄存器
+            // | sp     | sscratch
+            // | gp, tp | gp, tp
+            // | s0-s11 | 不支持
+            //
+            // > 若要保留陷入上下文，
+            // > 必须在快速路径保存 a0-a7 到 `TrapHandler.context`，
+            // > 并进入完整路径执行后续操作。
+            // >
+            // > 若要切换上下文，在快速路径设置 gp/tp/sscratch/sepc 和 sstatus。
+            "mv   a0, sp",
+            load!(sp[1] => ra),
+            "jalr ra",
+            "0:", // 加载上下文指针
+            load!(sp[0] => a1),
+            // 0：设置少量参数寄存器
+            "   beqz  a0, 0f",
+            // 1：设置所有参数寄存器
+            "   addi  a0, a0, -1
             beqz  a0, 1f
         ",
-        // 2：设置所有调用者寄存器
-        "   addi  a0, a0, -1
+            // 2：设置所有调用者寄存器
+            "   addi  a0, a0, -1
             beqz  a0, 2f
         ",
-        // 3：设置所有寄存器
-        "   addi  a0, a0, -1
+            // 3：设置所有寄存器
+            "   addi  a0, a0, -1
             beqz  a0, 3f
         ",
-        // 4：完整路径
-        save!(s0  => a1[16]),
-        save!(s1  => a1[17]),
-        save!(s2  => a1[18]),
-        save!(s3  => a1[19]),
-        save!(s4  => a1[20]),
-        save!(s5  => a1[21]),
-        save!(s6  => a1[22]),
-        save!(s7  => a1[23]),
-        save!(s8  => a1[24]),
-        save!(s9  => a1[25]),
-        save!(s10 => a1[26]),
-        save!(s11 => a1[27]),
-        // 调用完整路径函数
-        //
-        // | reg    | position
-        // | ------ | -
-        // | sp     | sscratch
-        // | gp, tp | gp, tp
-        // | else   | `TrapHandler.context`
-        //
-        // > 若要保留陷入上下文，
-        // > 在完整路径中保存 gp/tp/sp/pc 到 `TrapHandler.context`。
-        // >
-        // > 若要切换上下文，在完整路径设置 gp/tp/sscratch/sepc 和 sstatus。
-        "mv   a0, sp",
-        load!(sp[2] => ra),
-        "jalr ra",
-        "j    0b",
-        "3:", // 设置所有寄存器
-        load!(a1[16] => s0),
-        load!(a1[17] => s1),
-        load!(a1[18] => s2),
-        load!(a1[19] => s3),
-        load!(a1[20] => s4),
-        load!(a1[21] => s5),
-        load!(a1[22] => s6),
-        load!(a1[23] => s7),
-        load!(a1[24] => s8),
-        load!(a1[25] => s9),
-        load!(a1[26] => s10),
-        load!(a1[27] => s11),
-        "2:", // 设置所有调用者寄存器
-        load!(a1[ 0] => ra),
-        load!(a1[ 1] => t0),
-        load!(a1[ 2] => t1),
-        load!(a1[ 3] => t2),
-        load!(a1[ 4] => t3),
-        load!(a1[ 5] => t4),
-        load!(a1[ 6] => t5),
-        load!(a1[ 7] => t6),
-        "1:", // 设置所有参数寄存器
-        load!(a1[10] => a2),
-        load!(a1[11] => a3),
-        load!(a1[12] => a4),
-        load!(a1[13] => a5),
-        load!(a1[14] => a6),
-        load!(a1[15] => a7),
-        "0:", // 设置少量参数寄存器
-        load!(a1[ 8] => a0),
-        load!(a1[ 9] => a1),
-        exchange!(),
-        r#return!(),
-    )
+            // 4：完整路径
+            save!(s0  => a1[16]),
+            save!(s1  => a1[17]),
+            save!(s2  => a1[18]),
+            save!(s3  => a1[19]),
+            save!(s4  => a1[20]),
+            save!(s5  => a1[21]),
+            save!(s6  => a1[22]),
+            save!(s7  => a1[23]),
+            save!(s8  => a1[24]),
+            save!(s9  => a1[25]),
+            save!(s10 => a1[26]),
+            save!(s11 => a1[27]),
+            // 调用完整路径函数
+            //
+            // | reg    | position
+            // | ------ | -
+            // | sp     | sscratch
+            // | gp, tp | gp, tp
+            // | else   | `TrapHandler.context`
+            //
+            // > 若要保留陷入上下文，
+            // > 在完整路径中保存 gp/tp/sp/pc 到 `TrapHandler.context`。
+            // >
+            // > 若要切换上下文，在完整路径设置 gp/tp/sscratch/sepc 和 sstatus。
+            "mv   a0, sp",
+            load!(sp[2] => ra),
+            "jalr ra",
+            "j    0b",
+            "3:", // 设置所有寄存器
+            load!(a1[16] => s0),
+            load!(a1[17] => s1),
+            load!(a1[18] => s2),
+            load!(a1[19] => s3),
+            load!(a1[20] => s4),
+            load!(a1[21] => s5),
+            load!(a1[22] => s6),
+            load!(a1[23] => s7),
+            load!(a1[24] => s8),
+            load!(a1[25] => s9),
+            load!(a1[26] => s10),
+            load!(a1[27] => s11),
+            "2:", // 设置所有调用者寄存器
+            load!(a1[ 0] => ra),
+            load!(a1[ 1] => t0),
+            load!(a1[ 2] => t1),
+            load!(a1[ 3] => t2),
+            load!(a1[ 4] => t3),
+            load!(a1[ 5] => t4),
+            load!(a1[ 6] => t5),
+            load!(a1[ 7] => t6),
+            "1:", // 设置所有参数寄存器
+            load!(a1[10] => a2),
+            load!(a1[11] => a3),
+            load!(a1[12] => a4),
+            load!(a1[13] => a5),
+            load!(a1[14] => a6),
+            load!(a1[15] => a7),
+            "0:", // 设置少量参数寄存器
+            load!(a1[ 8] => a0),
+            load!(a1[ 9] => a1),
+            exchange!(),
+            r#return!(),
+        )
+    }
 }

--- a/fast-trap/src/hal/riscv/riscv_m.rs
+++ b/fast-trap/src/hal/riscv/riscv_m.rs
@@ -1,4 +1,4 @@
-﻿use super::{trap_entry, FlowContext};
+use super::{FlowContext, trap_entry};
 use core::arch::asm;
 
 macro_rules! exchange {

--- a/fast-trap/src/hal/riscv/riscv_m.rs
+++ b/fast-trap/src/hal/riscv/riscv_m.rs
@@ -23,17 +23,19 @@ impl FlowContext {
     /// 从上下文向硬件加载非调用规范约定的寄存器。
     #[inline]
     pub(crate) unsafe fn load_others(&self) {
-        asm!(
-            "   mv         gp, {gp}
+        unsafe {
+            asm!(
+                "   mv         gp, {gp}
                 mv         tp, {tp}
                 csrw mscratch, {sp}
                 csrw     mepc, {pc}
             ",
-            gp = in(reg) self.gp,
-            tp = in(reg) self.tp,
-            sp = in(reg) self.sp,
-            pc = in(reg) self.pc,
-        );
+                gp = in(reg) self.gp,
+                tp = in(reg) self.tp,
+                sp = in(reg) self.sp,
+                pc = in(reg) self.pc,
+            );
+        }
     }
 }
 
@@ -49,17 +51,19 @@ pub(crate) fn exchange_scratch(mut val: usize) -> usize {
 /// See [proto](crate::hal::doc::soft_trap).
 #[inline]
 pub unsafe fn soft_trap(cause: usize) {
-    asm!(
-        "   la   {0},    1f
+    unsafe {
+        asm!(
+            "   la   {0},    1f
             csrw mepc,   {0}
             csrw mcause, {cause}
             j    {trap}
          1:
         ",
-        out(reg) _,
-        cause = in(reg) cause,
-        trap  = sym trap_entry,
-    );
+            out(reg) _,
+            cause = in(reg) cause,
+            trap  = sym trap_entry,
+        );
+    }
 }
 
 /// # Safety
@@ -67,5 +71,5 @@ pub unsafe fn soft_trap(cause: usize) {
 /// See [proto](crate::hal::doc::load_direct_trap_entry).
 #[inline]
 pub unsafe fn load_direct_trap_entry() {
-    asm!("csrw mtvec, {0}", in(reg) trap_entry, options(nomem))
+    unsafe { asm!("csrw mtvec, {0}", in(reg) trap_entry, options(nomem)) }
 }

--- a/fast-trap/src/hal/riscv/riscv_s.rs
+++ b/fast-trap/src/hal/riscv/riscv_s.rs
@@ -1,4 +1,4 @@
-﻿use super::{trap_entry, FlowContext};
+use super::{FlowContext, trap_entry};
 use core::arch::asm;
 
 macro_rules! exchange {

--- a/fast-trap/src/hal/riscv/riscv_s.rs
+++ b/fast-trap/src/hal/riscv/riscv_s.rs
@@ -23,17 +23,19 @@ impl FlowContext {
     /// 从上下文向硬件加载非调用规范约定的寄存器。
     #[inline]
     pub(crate) unsafe fn load_others(&self) {
-        asm!(
-            "   mv         gp, {gp}
+        unsafe {
+            asm!(
+                "   mv         gp, {gp}
                 mv         tp, {tp}
                 csrw sscratch, {sp}
                 csrw     sepc, {pc}
             ",
-            gp = in(reg) self.gp,
-            tp = in(reg) self.tp,
-            sp = in(reg) self.sp,
-            pc = in(reg) self.pc,
-        );
+                gp = in(reg) self.gp,
+                tp = in(reg) self.tp,
+                sp = in(reg) self.sp,
+                pc = in(reg) self.pc,
+            );
+        }
     }
 }
 
@@ -51,17 +53,19 @@ pub(crate) fn exchange_scratch(mut val: usize) -> usize {
 /// 如同发生一个陷入。
 #[inline]
 pub unsafe fn soft_trap(cause: usize) {
-    asm!(
-        "   la   {0},    1f
+    unsafe {
+        asm!(
+            "   la   {0},    1f
             csrw sepc,   {0}
             csrw scause, {cause}
             j    {trap}
          1:
         ",
-        out(reg) _,
-        cause = in(reg) cause,
-        trap  = sym trap_entry,
-    );
+            out(reg) _,
+            cause = in(reg) cause,
+            trap  = sym trap_entry,
+        );
+    }
 }
 
 /// 设置全局陷入入口。
@@ -71,5 +75,5 @@ pub unsafe fn soft_trap(cause: usize) {
 /// 这个函数操作硬件寄存器，寄存器里原本的值将丢弃。
 #[inline]
 pub unsafe fn load_direct_trap_entry() {
-    asm!("csrw stvec, {0}", in(reg) trap_entry, options(nomem))
+    unsafe { asm!("csrw stvec, {0}", in(reg) trap_entry, options(nomem)) }
 }

--- a/fast-trap/src/lib.rs
+++ b/fast-trap/src/lib.rs
@@ -10,12 +10,12 @@ mod hal;
 
 pub use entire::*;
 pub use fast::*;
-pub use hal::{load_direct_trap_entry, reuse_stack_for_trap, soft_trap, trap_entry, FlowContext};
+pub use hal::{FlowContext, load_direct_trap_entry, reuse_stack_for_trap, soft_trap, trap_entry};
 
 use core::{
     alloc::Layout,
     marker::PhantomPinned,
-    mem::{align_of, forget, MaybeUninit},
+    mem::{MaybeUninit, align_of, forget},
     ops::Range,
     ptr::NonNull,
 };

--- a/fast-trap/src/lib.rs
+++ b/fast-trap/src/lib.rs
@@ -1,7 +1,7 @@
 //! 快速陷入处理。
 
 #![no_std]
-#![feature(naked_functions, asm_const)]
+#![feature(naked_functions)]
 #![deny(warnings, missing_docs)]
 
 mod entire;

--- a/test-app/Cargo.toml
+++ b/test-app/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-app"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["YdrMaster <ydrml@hotmail.com>"]
 publish = false
 

--- a/test-app/Cargo.toml
+++ b/test-app/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-app"
 version = "0.0.0"
-edition = "2024"
+edition.workspace = true
 authors = ["YdrMaster <ydrml@hotmail.com>"]
 publish = false
 

--- a/test-app/src/main.rs
+++ b/test-app/src/main.rs
@@ -5,14 +5,14 @@
 
 use core::{
     arch::asm,
-    mem::{forget, MaybeUninit},
-    ptr::{null, NonNull},
+    mem::{MaybeUninit, forget},
+    ptr::{NonNull, null},
     unreachable,
 };
 use dtb_walker::{Dtb, DtbObj, HeaderError, Str, WalkOperation};
 use fast_trap::{
-    load_direct_trap_entry, reuse_stack_for_trap, soft_trap, trap_entry, FastContext, FastResult,
-    FlowContext, FreeTrapStack,
+    FastContext, FastResult, FlowContext, FreeTrapStack, load_direct_trap_entry,
+    reuse_stack_for_trap, soft_trap, trap_entry,
 };
 use rcore_console::log;
 use riscv::register::*;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["YdrMaster <ydrml@hotmail.com>"]
 publish = false
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 authors = ["YdrMaster <ydrml@hotmail.com>"]
 publish = false
 


### PR DESCRIPTION
This pull request implements the following features.
- Update rust edition to 2024
- Use `naked_asm!` instead of `asm!` in all `#[naked]` functions, and removes `options(noreturn)` which is implicit with `naked_asm!`