### PR TITLE
replace #[naked] with #[unsafe(naked)] and remove #![feature(naked_functions)]

### DIFF
--- a/test-app/src/main.rs
+++ b/test-app/src/main.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(naked_functions)]
 #![deny(warnings)]
 
 use core::{
@@ -24,7 +23,7 @@ static mut ROOT_STACK: Stack = Stack([0; 4096]);
 static mut FREE_STACK: Stack = Stack([0; 4096]);
 static mut ROOT_CONTEXT: FlowContext = FlowContext::ZERO;
 
-#[naked]
+#[unsafe(naked)]
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".text.entry")]
 unsafe extern "C" fn _start() -> ! {
@@ -44,7 +43,7 @@ unsafe extern "C" fn _start() -> ! {
     }
 }
 
-#[naked]
+#[unsafe(naked)]
 unsafe extern "C" fn exception() -> ! {
     unsafe { naked_asm!("unimp") }
 }


### PR DESCRIPTION
replace #[naked] with #[unsafe(naked)] and remove #![feature(naked_functions)]

- Replaced all instances of #[naked] with #[unsafe(naked)] in main.rs, mod.rs, and lib.rs to align with the updated syntax.
- Removed the deprecated #![feature(naked_functions)] from the files as it is no longer required.

ref:
https://github.com/rust-lang/rust/pull/134213
https://github.com/rustsbi/rustsbi/issues/131

These changes were tested and passed in my fork's CI pipeline.