### PR TITLE
fix: replace #[naked] with #[unsafe(naked)] for stable Rust

### DIFF
--- a/fast-trap/src/hal/riscv/mod.rs
+++ b/fast-trap/src/hal/riscv/mod.rs
@@ -108,7 +108,7 @@ impl FlowContext {
 /// # Safety
 ///
 /// See [proto](crate::hal::doc::reuse_stack_for_trap).
-#[naked]
+#[unsafe(naked)]
 pub unsafe extern "C" fn reuse_stack_for_trap() {
     const LAYOUT: Layout = Layout::new::<TrapHandler>();
     unsafe {
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn reuse_stack_for_trap() {
 /// # Safety
 ///
 /// See [proto](crate::hal::doc::trap_entry).
-#[naked]
+#[unsafe(naked)]
 pub unsafe extern "C" fn trap_entry() {
     unsafe {
         core::arch::naked_asm!(


### PR DESCRIPTION
After [https://github.com/rust-lang/rust/pull/128651](https://github.com/rust-lang/rust/pull/128651) merged in nightly toolchain, asm! macro is not allowed in naked functions.

So what we need to do is just fix that.

**Change**:

- replace `#[naked]` with `#[unsafe(naked)]` for stable Rust